### PR TITLE
fix: new component grip placement

### DIFF
--- a/desktop-frontend/src/canvas/widget.py
+++ b/desktop-frontend/src/canvas/widget.py
@@ -283,6 +283,7 @@ class CanvasWidget(QWidget):
             suffix = component_data.get('suffix', '')
             svg = component_data.get('svg', '')
             parent = component_data.get('parent', '')
+            grips = component_data.get('grips', '')
         except (json.JSONDecodeError, ValueError):
             # Fallback for old format (plain text)
             object_name = text
@@ -291,13 +292,15 @@ class CanvasWidget(QWidget):
             suffix = ''
             svg = ''
             parent = ''
+            grips = ''
         
         self.create_component_command(object_name, pos, component_data={
             's_no': s_no,
             'legend': legend,
             'suffix': suffix,
             'svg': svg,
-            'parent': parent
+            'parent': parent,
+            'grips': grips,
         })
         event.acceptProposedAction()
 

--- a/desktop-frontend/src/grip_editor_dialog.py
+++ b/desktop-frontend/src/grip_editor_dialog.py
@@ -342,7 +342,8 @@ class GripEditorDialog(QDialog):
                 continue
 
             x_abs = left + (x_percent / 100.0) * width if width > 0 else left
-            y_abs = top + (y_percent / 100.0) * height if height > 0 else top
+            # Stored grips use renderer convention: y=100 at top, y=0 at bottom.
+            y_abs = top + ((100.0 - y_percent) / 100.0) * height if height > 0 else top
             self.points.append({"x": x_abs, "y": y_abs, "side": side})
 
         self.refresh_grips()
@@ -602,7 +603,8 @@ class GripEditorDialog(QDialog):
         percentage_grips = []
         for p in self.points:
             x_percent = ((p["x"] - left) / width) * 100.0 if width > 0 else 0
-            y_percent = ((p["y"] - top) / height) * 100.0 if height > 0 else 0
+            # Persist Y in renderer convention: y=100 at top, y=0 at bottom.
+            y_percent = (100.0 - ((p["y"] - top) / height) * 100.0) if height > 0 else 0
             
             percentage_grips.append({
                 "x": round(x_percent, 2),


### PR DESCRIPTION
Fix new-component grip handling in desktop canvas.

Preserve [grips](vscode-file://vscode-app/c:/Users/abhin/AppData/Local/Programs/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html) in toolbar drag/drop payload so dropped new components keep correct grip count.
Align Grip Editor Y-axis serialization/deserialization with renderer convention to fix grip positions.
Result: new components now render expected grip count and placement consistently.