### PR TITLE
enhancement: Make image resize zoom-aware and commit once

### DIFF
--- a/web-frontend/src/components/Canvas/CanvasItemImage.tsx
+++ b/web-frontend/src/components/Canvas/CanvasItemImage.tsx
@@ -12,7 +12,7 @@ import { Rect } from "react-konva";
 
 import { calculateAspectFit } from "../../utils/layout";
 
-import { CanvasItemImageProps } from "./types";
+import { CanvasItem, CanvasItemImageProps } from "./types";
 
 const LABEL_OFFSET = 4;
 
@@ -24,6 +24,7 @@ export const CanvasItemImage = ({
   onChange,
   onDragEnd,
   onTransformEnd,
+  stageScale = 1,
   onGripMouseDown,
   onGripMouseEnter,
   onGripMouseLeave,
@@ -34,6 +35,20 @@ export const CanvasItemImage = ({
 
   const groupRef = useRef<Konva.Group>(null);
   const trRef = useRef<Konva.Transformer>(null);
+  // Track Shift key state via a ref so we can read it inside boundBoxFunc
+  // without changing Konva's strict 2-arg boundBoxFunc signature.
+  const shiftHeldRef = useRef(false);
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => { shiftHeldRef.current = e.shiftKey; };
+    const onKeyUp   = (e: KeyboardEvent) => { shiftHeldRef.current = e.shiftKey; };
+    window.addEventListener("keydown", onKeyDown);
+    window.addEventListener("keyup",   onKeyUp);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("keyup",   onKeyUp);
+    };
+  }, []);
 
   useEffect(() => {
     if (isSelected && trRef.current && groupRef.current) {
@@ -61,20 +76,28 @@ export const CanvasItemImage = ({
     const scaleX = node.scaleX();
     const scaleY = node.scaleY();
 
+    // Reset Konva's internal scale back to 1 — we store true pixel dimensions
     node.scaleX(1);
     node.scaleY(1);
 
-    const updatedItem = {
+    // Zoom-aware 20px logical minimum: at zoom 0.5 the threshold is 40 screen px
+    const MIN_PX = 20 / (stageScale > 0 ? stageScale : 1);
+
+    const updatedItem: CanvasItem = {
       ...item,
       x: node.x(),
       y: node.y(),
-      width: Math.max(5, item.width * Math.abs(scaleX)),
-      height: Math.max(5, item.height * Math.abs(scaleY)),
+      width: Math.max(MIN_PX, item.width * Math.abs(scaleX)),
+      height: Math.max(MIN_PX, item.height * Math.abs(scaleY)),
       rotation: node.rotation(),
     };
 
-    onChange(updatedItem);
+    // ① Fire the commit callback FIRST so Editor.tsx can push ONE undo snapshot.
+    //    (onTransformEnd is only called at drag-end, not on every pixel moved.)
     onTransformEnd?.(updatedItem);
+
+    // ② Also update visual state so grips / labels reposition immediately.
+    onChange(updatedItem);
   };
 
   const labelText = item.label || item.name;
@@ -166,8 +189,23 @@ export const CanvasItemImage = ({
         <Transformer
           ref={trRef}
           boundBoxFunc={(oldBox, newBox) => {
-            // Prevent shrinking too small
-            if (newBox.width < 10 || newBox.height < 10) {
+            // Zoom-aware 20px logical minimum
+            const MIN = 20 / (stageScale > 0 ? stageScale : 1);
+
+            // Shift key → lock aspect ratio regardless of which handle is dragged
+            if (shiftHeldRef.current) {
+              const ratio = oldBox.width / oldBox.height;
+              const dw = Math.abs(newBox.width - oldBox.width);
+              const dh = Math.abs(newBox.height - oldBox.height);
+              if (dw >= dh) {
+                newBox = { ...newBox, height: newBox.width / ratio };
+              } else {
+                newBox = { ...newBox, width: newBox.height * ratio };
+              }
+            }
+
+            // Enforce minimum — revert if either dimension would go below 20px
+            if (newBox.width < MIN || newBox.height < MIN) {
               return oldBox;
             }
 
@@ -175,13 +213,17 @@ export const CanvasItemImage = ({
           }}
           enabledAnchors={[
             "top-left",
+            "top-center",
             "top-right",
+            "middle-left",
+            "middle-right",
             "bottom-left",
+            "bottom-center",
             "bottom-right",
           ]}
-          flipEnabled={false} // Disable flipping to prevent negative scale issues
-          keepRatio={true} // Enforce aspect ratio scaling
-          rotateEnabled={false} // Disable rotation
+          flipEnabled={false}   // Prevent negative-scale artifacts
+          keepRatio={false}     // Ratio is controlled manually via Shift in boundBoxFunc
+          rotateEnabled={false} // Rotation not needed for PFD components
         />
       )}
 

--- a/web-frontend/src/components/Canvas/types.ts
+++ b/web-frontend/src/components/Canvas/types.ts
@@ -83,7 +83,11 @@ export interface CanvasItemImageProps {
   onSelect: (e?: KonvaEventObject<MouseEvent>) => void; // Strict typing
   onChange: (newAttrs: CanvasItem) => void;
   onDragEnd?: (item: CanvasItem) => void;
+  /** Called ONCE when the user finishes a resize gesture (mouseUp). Use this
+   *  to commit to the global store so only one undo snapshot is pushed. */
   onTransformEnd?: (item: CanvasItem) => void;
+  /** Current canvas zoom/scale — used to compute a zoom-aware minimum size. */
+  stageScale?: number;
   onGripMouseDown?: (
     itemId: number,
     gripIndex: number,

--- a/web-frontend/src/pages/Editor.tsx
+++ b/web-frontend/src/pages/Editor.tsx
@@ -82,6 +82,15 @@ import {
 //   type SavedProject,
 //   convertToBackendFormat,
 // } from "@/utils/projectStorage";
+import { appendFooterToImage } from "@/utils/exportFooter";
+
+// import {
+//   getProject,
+//   saveProject,
+//   createProject,
+//   type SavedProject,
+//   convertToBackendFormat,
+// } from "@/utils/projectStorage";
 import {
   createProject,
   fetchProject,
@@ -612,6 +621,13 @@ export default function Editor() {
       // Clean up temp stage
       tempStage.destroy();
       document.body.removeChild(tempContainer);
+
+      // Append Footer Block (mimicking PyQt title block)
+      const projectName = projectMetadata?.name || "Untitled Project";
+      const createdBy = localStorage.getItem("username") || "Unknown User";
+      const exportDate = new Date().toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" });
+
+      dataUrl = await appendFooterToImage(dataUrl, projectName, createdBy, exportDate, backgroundFill, pixelRatio);
 
       /* =========================
      PDF EXPORT - FIXED
@@ -1356,6 +1372,34 @@ export default function Editor() {
     }
   };
 
+  /**
+   * Called ONCE when the user finishes a resize gesture (Konva onTransformEnd).
+   * Writes the final dimensions to the store in a single atomic update so only
+   * ONE undo snapshot is pushed — mirroring the desktop ResizeCommand pattern.
+   * Also resets waypoints on connected pipes so they re-route around the new bounds.
+   */
+  const handleResizeEnd = (item: CanvasItem) => {
+    if (!projectId) return;
+
+    // Single atomic store write = single undo entry
+    editorStore.updateItem(projectId, item.id, {
+      x: item.x,
+      y: item.y,
+      width: item.width,
+      height: item.height,
+      rotation: item.rotation,
+    });
+
+    // Reset waypoints for all pipes attached to this component so they re-route
+    const relatedConnections = connections.filter(
+      (conn) => conn.sourceItemId === item.id || conn.targetItemId === item.id,
+    );
+
+    relatedConnections.forEach((conn) => {
+      editorStore.updateConnection(projectId, conn.id, { waypoints: [] });
+    });
+  };
+
   const handleSelectItem = (
     itemId: number,
     e?: Konva.KonvaEventObject<MouseEvent>,
@@ -2086,6 +2130,7 @@ export default function Editor() {
                     isInvalid={isInvalid}
                     isSelected={selectedItemIds.has(item.id)}
                     item={item}
+                    stageScale={stageScale}
                     onChange={(newAttrs) =>
                       handleUpdateItem(newAttrs.id, newAttrs)
                     }
@@ -2093,6 +2138,7 @@ export default function Editor() {
                     onGripMouseEnter={handleGripMouseEnter}
                     onGripMouseLeave={handleGripMouseLeave}
                     onSelect={(e) => handleSelectItem(item.id, e)}
+                    onTransformEnd={handleResizeEnd}
                   />
                 );
               })}


### PR DESCRIPTION
Add zoom-aware resizing to CanvasItemImage: introduce stageScale prop, enforce a 20px logical minimum (scaled by canvas zoom), and reset Konva internal scale to keep stored dimensions in pixels.
- Implement Shift-key aspect-ratio locking via a ref and global key listeners, and move ratio logic into the transform boundBoxFunc (keepRatio disabled).
- Introduce onTransformEnd (types updated) and call it before onChange so the editor can commit a single undo snapshot; Editor.tsx adds handleResizeEnd to persist the final size and clear connected pipe waypoints, and passes stageScale and onTransformEnd to the image component.
- Also adjust transformer anchors and disable flipping/rotation to avoid negative-scale artifacts.