### PR TITLE
fix: preserve undo / redo history for component addition

### DIFF
--- a/web-frontend/src/pages/Editor.tsx
+++ b/web-frontend/src/pages/Editor.tsx
@@ -1340,8 +1340,17 @@ export default function Editor() {
       }
     }
 
-    // Single item update
-    editorStore.updateItem(projectId, itemId, snappedUpdates);
+    // Skip history entry for image metadata sync
+const isMetadataSync =
+  "naturalWidth" in snappedUpdates ||
+  "naturalHeight" in snappedUpdates;
+
+editorStore.updateItem(
+  projectId,
+  itemId,
+  snappedUpdates,
+  !isMetadataSync,
+);
 
     // If the component moved, reset connection waypoints so routing recalculates
     if (updates.x !== undefined || updates.y !== undefined) {

--- a/web-frontend/src/store/useEditorStore.ts
+++ b/web-frontend/src/store/useEditorStore.ts
@@ -48,10 +48,11 @@ interface EditorStore {
   ) => CanvasItem | undefined;
 
   updateItem: (
-    editorId: string,
-    itemId: number,
-    patch: Partial<CanvasItem>,
-  ) => void;
+  editorId: string,
+  itemId: number,
+  patch: Partial<CanvasItem>,
+  recordHistory?: boolean,
+) => void;
 
   deleteItem: (editorId: string, itemId: number) => void;
 
@@ -284,31 +285,40 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
     return newItem;
   },
 
-  updateItem: (editorId, itemId, patch) => {
-    set((s) => {
-      const ed = s.editors[editorId];
+  updateItem: (
+  editorId,
+  itemId,
+  patch,
+  recordHistory = true,
+) => {
+  set((s) => {
+    const ed = s.editors[editorId];
 
-      if (!ed) return s;
+    if (!ed) return s;
 
-      // --- RECORD HISTORY ---
-      const snapshot = createSnapshot(ed);
-      // ----------------------
+    const snapshot = recordHistory
+      ? createSnapshot(ed)
+      : null;
 
-      return {
-        editors: {
-          ...s.editors,
-          [editorId]: {
-            ...ed,
-            items: ed.items.map((it) =>
-              it.id === itemId ? { ...it, ...patch } : it,
-            ),
-            past: [...ed.past, snapshot],
-            future: [],
-          },
+    return {
+      editors: {
+        ...s.editors,
+        [editorId]: {
+          ...ed,
+          items: ed.items.map((it) =>
+            it.id === itemId ? { ...it, ...patch } : it,
+          ),
+          past: snapshot
+            ? [...ed.past, snapshot]
+            : ed.past,
+          future: recordHistory
+            ? []
+            : ed.future,
         },
-      };
-    });
-  },
+      },
+    };
+  });
+},
 
   deleteItem: (editorId, itemId) => {
     set((s) => {


### PR DESCRIPTION
Fixes undo/redo behavior for component add actions.

Root Cause:
Automatic image metadata synchronization (naturalWidth/naturalHeight)
was creating an extra history entry immediately after component creation,
preventing undo from reverting component additions.

Solution:
Skip history recording for metadata-only updates while preserving
undo/redo functionality for user actions such as add, move, resize,
rotate, and delete.