### PR TITLE
Fix component image resizing with bounding box

### DIFF
--- a/web-frontend/src/components/Canvas/CanvasItemImage.tsx
+++ b/web-frontend/src/components/Canvas/CanvasItemImage.tsx
@@ -43,9 +43,7 @@ export const CanvasItemImage = ({
     onChange(updatedItem);
     onDragEnd?.(updatedItem);
   };
-
-
-
+  
   const labelText = item.label || item.name;
 
   const labelX = item.x;
@@ -104,11 +102,11 @@ export const CanvasItemImage = ({
           />
         )}
         <KonvaImage
-          height={renderHeight}
           image={image || undefined}
-          width={renderWidth}
-          x={renderX}
-          y={renderY}
+          height={item.height}
+          width={item.width}
+          x={0}
+          y={0}
           onClick={(e) => onSelect(e as any)}
           onTap={(e) => onSelect(e as any)}
         />


### PR DESCRIPTION
## Summary

This PR updates component resizing behavior so that the rendered image resizes together with the bounding box.

### Changes
- Updated `CanvasItemImage` to render the image using the resized component dimensions.
- Removed aspect-fit rendering during interactive resize.
- Preserved independent width and height resizing.

### Result
- Width-only resize stretches the component horizontally.
- Height-only resize stretches the component vertically.
- Corner resize updates both dimensions correctly.
- Labels remain correctly positioned relative to the resized component.

### Testing
- Width resize
- Height resize
- Corner resize
- Component selection
- Drag and move after resize
- Undo/Redo